### PR TITLE
Switchtodougn

### DIFF
--- a/cookbooks/rogue/README.md
+++ b/cookbooks/rogue/README.md
@@ -1,6 +1,6 @@
 ROGUE Cookbook
 ===============
-A stand-alone chef cookbook for the ROGUE-JCTD project.  This cookbook can be used to install and configure all of the ROGUE components.
+A stand-alone chef cookbook for the DOUGN project, forked from ROGUE-JCTD project.  This cookbook can be used to install and configure all of the ROGUE components.
 
 NOTE: This version enhanced for use with eCAP automated deployment.  See applications/README.md for details
 
@@ -166,7 +166,7 @@ The unison recipe will:
 #### rogue::stig
 The stig recipe will:
 
-- Do a git pull from the ROGUE-JCTD stig repository.
+- Do a git pull from the DOUGN stig repository.
 
 How To
 ------

--- a/cookbooks/rogue/attributes/default.rb
+++ b/cookbooks/rogue/attributes/default.rb
@@ -1,5 +1,5 @@
 default['rogue']['debug'] = true
-default['rogue']['version'] = '1.x'
+default['rogue']['version'] = 'v0.1a'
 
 node.normal.postgresql.enable_pgdg_apt = true
 

--- a/cookbooks/rogue/attributes/default.rb
+++ b/cookbooks/rogue/attributes/default.rb
@@ -39,18 +39,18 @@ default['rogue']['geoserver']['jai_io']['url'] = "http://download.java.net/media
 default['rogue']['geoserver']['url']= "http://#{node.rogue.rogue_geonode.public_address}#{node['rogue']['geoserver']['base_url']}/"
 default['rogue']['geoserver']['war'] = "http://jenkins.rogue.lmnsolutions.com/job/geoserver/lastSuccessfulBuild/artifact/geoserver_ext/target/geoserver.war"
 
-default['rogue']['geoserver_data']['url'] = 'https://github.com/ROGUE-JCTD/geoserver_data.git'
+default['rogue']['geoserver_data']['url'] = 'https://github.com/DistributedOpenUnifiedGovernmentNetwork/geoserver_data.git'
 default['rogue']['geoserver_data']['branch'] = 'master'
 
 default['rogue']['geonode']['location'] = '/var/lib/geonode/'
 default['rogue']['interpreter'] = ::File.join(node['rogue']['geonode']['location'], 'bin/python')
 default['rogue']['django_maploom']['auto_upgrade'] = true
-default['rogue']['django_maploom']['url'] = "git+https://github.com/ROGUE-JCTD/django-maploom.git#egg=django-maploom"
+default['rogue']['django_maploom']['url'] = "git+https://github.com/DistributedOpenUnifiedGovernmentNetwork/django-maploom.git#egg=django-maploom"
 default['rogue']['geonode']['location'] = '/var/lib/geonode/'
 default['rogue']['rogue_geonode']['branch'] = 'master'
 default['rogue']['rogue_geonode']['python_packages'] = ["uwsgi", "psycopg2"]
 default['rogue']['rogue_geonode']['location'] = File.join(node['rogue']['geonode']['location'], 'rogue_geonode')
-default['rogue']['rogue_geonode']['url'] = 'https://github.com/ROGUE-JCTD/rogue_geonode.git'
+default['rogue']['rogue_geonode']['url'] = 'https://github.com/DistributedOpenUnifiedGovernmentNetwork/rogue_geonode.git'
 default['rogue']['rogue_geonode']['fixtures'] = ['sample_admin.json',]
 default['rogue']['rogue_geonode']['settings']['ALLOWED_HOSTS'] = [node['ipaddress'], 'localhost', node.rogue.rogue_geonode.public_address]
 default['rogue']['rogue_geonode']['settings']['PROXY_ALLOWED_HOSTS'] = ['*', '.lmnsolutions.com', '.openstreetmap.org']
@@ -78,7 +78,7 @@ default['rogue']['geogit']['build_from_source'] = false
 default['rogue']['geogit']['branch'] = 'SprintRelease'
 
 if node['rogue']['geogit']['build_from_source']
-  default['rogue']['geogit']['url'] = 'https://github.com/ROGUE-JCTD/GeoGit.git'
+  default['rogue']['geogit']['url'] = 'https://github.com/DistributedOpenUnifiedGovernmentNetwork/GeoGit.git'
 else
   default['rogue']['geogit']['url'] = 'http://jenkins.rogue.lmnsolutions.com/job/geogit/lastSuccessfulBuild/artifact/src/cli-app/target/geogit-cli-app.zip'
 end
@@ -92,7 +92,7 @@ default['rogue']['geogit']['location'] = '/var/lib/geogit'
 
 default['rogue']['geoeserver-exts']['branch'] = '2.4.x'
 default['rogue']['geoeserver-exts']['location'] = '/var/lib/geoserver-exts'
-default['rogue']['geoeserver-exts']['url'] = 'https://github.com/ROGUE-JCTD/geoserver-exts.git'
+default['rogue']['geoeserver-exts']['url'] = 'https://github.com/DistributedOpenUnifiedGovernmentNetwork/geoserver-exts.git'
 default['rogue']['tomcat']['log_dir'] = "${catalina.base}/logs"
 
 default['rogue']['rogue_geonode']['settings']['CLASSIFICATION_BANNER_ENABLED'] = false
@@ -100,12 +100,12 @@ default['rogue']['rogue_geonode']['settings']['CLASSIFICATION_TEXT_COLOR'] = nil
 default['rogue']['rogue_geonode']['settings']['CLASSIFICATION_BACKGROUND_COLOR'] = nil
 default['rogue']['rogue_geonode']['settings']['CLASSIFICATION_TEXT'] = nil
 
-default['rogue']['stig']['url'] = 'https://github.com/ROGUE-JCTD/stig.git'
+default['rogue']['stig']['url'] = 'https://github.com/DistributedOpenUnifiedGovernmentNetwork/stig.git'
 default['rogue']['stig']['branch'] = 'master'
 
 default['rogue']['rogue-scripts']['branch'] = 'master'
 default['rogue']['rogue-scripts']['location'] = '/opt/rogue-scripts'
-default['rogue']['rogue-scripts']['url'] = 'https://github.com/ROGUE-JCTD/rogue-scripts.git'
+default['rogue']['rogue-scripts']['url'] = 'https://github.com/DistributedOpenUnifiedGovernmentNetwork/rogue-scripts.git'
 
 if node['rogue']['version'] == '1.x'
   default['rogue']['rogue_geonode']['branch'] = '1.x'

--- a/cookbooks/rogue/attributes/iaff.rb
+++ b/cookbooks/rogue/attributes/iaff.rb
@@ -1,3 +1,3 @@
 default['rogue']['iaff_geoshape']['branch'] = 'master'
 default['rogue']['iaff_geoshape']['location'] = File.join(node['rogue']['geonode']['location'], 'iaff_geoshape')
-default['rogue']['iaff_geoshape']['url'] = 'https://github.com/ROGUE-JCTD/iaff_geoshape.git'
+default['rogue']['iaff_geoshape']['url'] = 'https://github.com/DistributedOpenUnifiedGovernmentNetwork/iaff_geoshape.git'

--- a/cookbooks/rogue/recipes/geogit.rb
+++ b/cookbooks/rogue/recipes/geogit.rb
@@ -51,6 +51,7 @@ node['rogue']['geogit']['global_configuration'].each do |section, values|
       bash "geogit global config #{section}.#{key} #{value}" do
         code "#{File.join(geogit_home, '/bin/geogit')} config --global #{section}.#{key} #{value}"
         user node['tomcat']['user']
+	action :nothing
       end
     end
 end

--- a/deploy_examples.txt
+++ b/deploy_examples.txt
@@ -1,0 +1,2 @@
+cap-deploy -n /opt/ecap/geocloud-ecap/applications/vpc/dev_only.json -p azskip=us-east-1a > ~/vpcdeploy.out 
+cap-deploy /opt/ecap/geocloud-ecap/applications/geoshape_geonode/master.json -p azskip=us-east-1a -p deploy_id=INFSTR-DEV-2014121617-BU


### PR DESCRIPTION
- Switch the application repositories to DOUGN 
  https://github.com/DistributedOpenUnifiedGovernmentNetwork
- Set the default version to 0.1a, which is the way we tagged DOUGN repositories forked from ROGUE-JCTD before the reorganization caused our deploys to stop working
## Important note

There's a bug in GeoShape, where the geogit,rb recipe tries to set the geogit global variables for the tomcat7 user, but the tomcat7 user has no home directory, so the deploy hangs.  In this merge we've disabled the run of that resource, and therefore probably disabled the geogit features.  To be fixed properly in a future commit.
