### PR TITLE
Adjust to new vpc capabilities

### DIFF
--- a/applications/geoshape_geonode/bastion.json
+++ b/applications/geoshape_geonode/bastion.json
@@ -1,8 +1,8 @@
 		{
-			"name": "bastion",
+			"name": "<%=$bastion_name %>",
 <%= include("../centos-ami.json") %>,
-			"ssh_user":"root",
-			"size": "m3.medium",
+			"ssh_user":"<%=$nat_ssh_user %>",
+			"size": "t2.medium",
 			"src-dst-check":false,
 			"iam-policies":[
 <%= include("../default_iam_node_policies.json") %>
@@ -11,7 +11,7 @@
 				"assign_ip":true
 			},
 			"vpc": {
-				"vpc_name":"geoshape-geonode-vpc",
+				"vpc_name":"<%=vpc_name %>",
 				"subnet_name":"Public1"
 			},
 			"ingress_rules":[

--- a/applications/geoshape_geonode/bastion.json
+++ b/applications/geoshape_geonode/bastion.json
@@ -11,7 +11,7 @@
 				"assign_ip":true
 			},
 			"vpc": {
-				"vpc_name":"<%=vpc_name %>",
+				"vpc_name":"<%=$vpc_name %>",
 				"subnet_name":"Public1"
 			},
 			"ingress_rules":[

--- a/applications/geoshape_geonode/lb.json
+++ b/applications/geoshape_geonode/lb.json
@@ -1,7 +1,7 @@
 		{
 			"name":"main",
 			"vpc": {
-				"vpc_name":"<%=vpc_name %>",
+				"vpc_name":"<%=$vpc_name %>",
 				"subnets":[
 					{
 						"subnet_name":"Public1"

--- a/applications/geoshape_geonode/lb.json
+++ b/applications/geoshape_geonode/lb.json
@@ -1,8 +1,7 @@
 		{
 			"name":"main",
 			"vpc": {
-<% if !$deploy_id then %>
-				"vpc_name":"geoshape-geonode-vpc",
+				"vpc_name":"<%=vpc_name %>",
 				"subnets":[
 					{
 						"subnet_name":"Public1"
@@ -14,25 +13,9 @@
 						"subnet_name":"Public3"
 					}
 				]
-<% else %>
-	<% if $environment == "dev" then %>
-				"vpc_name":"dev-vpc",
-	<% elsif $environment == "prod" then %>
-				"vpc_name":"prod-vpc",
-	<% end %>
-				"deploy_id":"<%= $deploy_id %>",
-				"subnets":[
-					{
-						"subnet_name":"PubSubnet1"
-					},
-					{
-						"subnet_name":"PubSubnet2"
-					},
-					{
-						"subnet_name":"PubSubnet3"
-					}
-				]
-
+<% if !$deploy_id then %>
+				,
+				"deploy_id":"<%= $deploy_id %>"
 <% end %>
 			},
 			"cross_zone_unstickiness":true,

--- a/applications/geoshape_geonode/lb.json
+++ b/applications/geoshape_geonode/lb.json
@@ -1,11 +1,10 @@
 		{
 			"name":"main",
 			"vpc": {
-				"vpc_name":"<%=$vpc_name %>",
-<% if !$deploy_id then %>
-				,
-				"deploy_id":"<%= $deploy_id %>"
-<% end %>
+				<% if $deploy_id then %>
+					"deploy_id":"<%= $deploy_id %>",
+				<% end %>
+				"vpc_name":"<%=$vpc_name %>"
 			},
 			"cross_zone_unstickiness":true,
 			"idle_timeout":1020,

--- a/applications/geoshape_geonode/lb.json
+++ b/applications/geoshape_geonode/lb.json
@@ -2,17 +2,6 @@
 			"name":"main",
 			"vpc": {
 				"vpc_name":"<%=$vpc_name %>",
-				"subnets":[
-					{
-						"subnet_name":"Public1"
-					},
-					{
-						"subnet_name":"Public2"
-					},
-					{
-						"subnet_name":"Public3"
-					}
-				]
 <% if !$deploy_id then %>
 				,
 				"deploy_id":"<%= $deploy_id %>"

--- a/applications/geoshape_geonode/master.json
+++ b/applications/geoshape_geonode/master.json
@@ -1,18 +1,24 @@
 {
 <%
-
+# set up defaults
 $ubuntu = true if !$centos
 $centos = true if !$ubuntu
 if $ubuntu and $centos
 	raise "You must specify either ubuntu or centos"
 end
-
 $public_db=false if !$public_db
-
+$bastion_name="bastion" if !$bastion_name
+$nat_ssh_user="root" if !$nat_ssh_user
+$region = "us-east-1" if !$region
+$appname="geoshape" if !$appname
+$vpc_name = $appname+"-vpc" if !$vpc_name
+$public_subnet = "Public" if !$public_subnet
+puts "Deploying with bastion name, nat ssh user, region, appname, vpc name, deploy id and public subnet ",$bastion_name, $nat_ssh_user, $region, $appname, $vpc_name,$deploy_id,$public_subnet
 %>
 
-	"appname": "geoshape",
-	"region": "us-east-1",
+
+	"appname": "<%=$appname %>",
+	"region": "<%=$region %>",
 	"admins": [
 		{
 			"name": "Ami Rahav",

--- a/applications/geoshape_geonode/pool.json
+++ b/applications/geoshape_geonode/pool.json
@@ -30,7 +30,7 @@
 			"vpc": {
 				"vpc_name":"<%=$vpc_name %>",
 				<% if $deploy_id then %>
-        "deploy_id":"<%= $deploy_id %>,"
+        "deploy_id":"<%= $deploy_id %>",
 				<% end %>
 				"subnet_pref": "all_private",
 				"nat_host_name":"<%=$bastion_name %>",
@@ -57,9 +57,9 @@
 <%= include("../default_iam_node_policies.json") %>
 					],
 <% if $environment == "dev" then %>
-					"size":"m3.small",
-<% else %>
 					"size":"m3.medium",
+<% else %>
+					"size":"m3.large",
 <% end %>
 					"storage":[
 						{

--- a/applications/geoshape_geonode/pool.json
+++ b/applications/geoshape_geonode/pool.json
@@ -1,5 +1,5 @@
 		{
-			"name":"geonode",
+			"name":"geoshape-pool",
 			"min-size":1,
 			"max-size":1,
 			"associate-public-ip":true,
@@ -29,17 +29,7 @@
 			],
 			"vpc": {
 				"vpc_name":"<%=$vpc_name %>",
-				"subnets":[
-					{
-						"subnet_name":"Public1"
-					},
-					{
-						"subnet_name":"Public2"
-					},
-					{
-						"subnet_name":"Public3"
-					}
-				],
+				"subnet_pref": "all_private",
 				"nat_host_name":"<%=$bastion_name %>",
 				"nat_ssh_user":"<%=$nat_ssh_user %>",
 <% if !$deploy_id then %>

--- a/applications/geoshape_geonode/pool.json
+++ b/applications/geoshape_geonode/pool.json
@@ -27,11 +27,8 @@
 					"rule_name":"geoshape_geonode"
 				}
 			],
-			"vpc":{
-<% if !$deploy_id then %>
-				"vpc_name":"geoshape-geonode-vpc",
-				"nat_host_name":"bastion",
-				"nat_ssh_user":"root",
+			"vpc": {
+				"vpc_name":"<%=vpc_name %>",
 				"subnets":[
 					{
 						"subnet_name":"Public1"
@@ -42,28 +39,12 @@
 					{
 						"subnet_name":"Public3"
 					}
-				]
-<% else %>
-	<% if $environment == "dev" then %>
-				"vpc_name":"dev-vpc",
-				"nat_host_name":"dev-vpc-bastion",
-	<% elsif $environment == "prod" then %>
-				"vpc_name":"prod-vpc",
-				"nat_host_name":"prod-vpc-bastion",
-	<% end %>
-				"deploy_id":"<%= $deploy_id %>",
-				"nat_ssh_user":"root",
-				"subnets":[
-					{
-						"subnet_name":"PubSubnet1"
-					},
-					{
-						"subnet_name":"PubSubnet2"
-					},
-					{
-						"subnet_name":"PubSubnet3"
-					}
-				]
+				],
+				"nat_host_name":"<%=$bastion_name %>",
+				"ssh_user":"<%=$nat_ssh_user %>",
+<% if !$deploy_id then %>
+				,
+				"deploy_id":"<%= $deploy_id %>"
 <% end %>
 			},
 		    "vault_access" : [{
@@ -87,9 +68,9 @@
 <%= include("../default_iam_node_policies.json") %>
 					],
 <% if $environment == "dev" then %>
-					"size":"m3.large",
+					"size":"m3.small",
 <% else %>
-					"size":"m3.xlarge",
+					"size":"m3.medium",
 <% end %>
 					"storage":[
 						{

--- a/applications/geoshape_geonode/pool.json
+++ b/applications/geoshape_geonode/pool.json
@@ -41,7 +41,7 @@
 					}
 				],
 				"nat_host_name":"<%=$bastion_name %>",
-				"ssh_user":"<%=$nat_ssh_user %>",
+				"nat_ssh_user":"<%=$nat_ssh_user %>",
 <% if !$deploy_id then %>
 				,
 				"deploy_id":"<%= $deploy_id %>"

--- a/applications/geoshape_geonode/pool.json
+++ b/applications/geoshape_geonode/pool.json
@@ -29,13 +29,12 @@
 			],
 			"vpc": {
 				"vpc_name":"<%=$vpc_name %>",
+				<% if $deploy_id then %>
+        "deploy_id":"<%= $deploy_id %>,"
+				<% end %>
 				"subnet_pref": "all_private",
 				"nat_host_name":"<%=$bastion_name %>",
-				"nat_ssh_user":"<%=$nat_ssh_user %>",
-<% if !$deploy_id then %>
-				,
-				"deploy_id":"<%= $deploy_id %>"
-<% end %>
+				"nat_ssh_user":"<%=$nat_ssh_user %>"
 			},
 		    "vault_access" : [{
 		            "vault" : "geoshape_geonode",

--- a/applications/geoshape_geonode/pool.json
+++ b/applications/geoshape_geonode/pool.json
@@ -28,7 +28,7 @@
 				}
 			],
 			"vpc": {
-				"vpc_name":"<%=vpc_name %>",
+				"vpc_name":"<%=$vpc_name %>",
 				"subnets":[
 					{
 						"subnet_name":"Public1"

--- a/applications/geoshape_geonode/postgis_dbs.json
+++ b/applications/geoshape_geonode/postgis_dbs.json
@@ -31,7 +31,7 @@
 				],
 <% end %>
 				"vpc":{
-					"vpc_name":"<%=vpc_name %>"
+					"vpc_name":"<%=$vpc_name %>"
 					"nat_host_name":"<%=$bastion_name %>",
 					"nat_ssh_user":"<%=$nat_ssh_user %>",
 <% if !$deploy_id then %>

--- a/applications/geoshape_geonode/postgis_dbs.json
+++ b/applications/geoshape_geonode/postgis_dbs.json
@@ -2,10 +2,10 @@
 				"name":"postgis",
 				"engine":"postgres",
 <% if $environment == "prod" then %>
-				"size":"db.m3.xlarge",
+				"size":"db.m3.large",
 				"storage":200,
 <% else %>
-				"size":"db.m3.large",
+				"size":"db.m3.medium",
 				"storage":30,
 <% end %>
 				"port":5432,
@@ -31,10 +31,10 @@
 				],
 <% end %>
 				"vpc":{
+					"vpc_name":"<%=vpc_name %>"
+					"nat_host_name":"<%=$bastion_name %>",
+					"nat_ssh_user":"<%=$nat_ssh_user %>",
 <% if !$deploy_id then %>
-				"vpc_name":"geoshape-geonode-vpc",
-				"nat_host_name":"bastion",
-				"nat_ssh_user":"root",
 				"subnets":[
 	<% if $public_db then %>
 					{
@@ -59,16 +59,8 @@
 	<% end %>
 				]
 <% else %>
-	<% if $environment == "dev" then %>
-				"vpc_name":"dev-vpc",
-				"nat_host_name":"dev-vpc-bastion",
-	<% elsif $environment == "prod" then %>
-				"vpc_name":"prod-vpc",
-				"nat_host_name":"prod-vpc-bastion",
-	<% end %>
-				"deploy_id":"<%= $deploy_id %>",
-				"nat_ssh_user":"root",
-				"subnets":[
+	"deploy_id":"<%= $deploy_id %>",
+		"subnets":[
 	<% if $public_db then %>
 					{
 						"subnet_name":"PubSubnet1"

--- a/applications/geoshape_geonode/security_groups.json
+++ b/applications/geoshape_geonode/security_groups.json
@@ -2,7 +2,7 @@
 			"name":"geoshape_geonode_lb",
 			
 			"vpc":{
-				"vpc_name":"<%=vpc_name %>",
+				"vpc_name":"<%=$vpc_name %>",
 <% if $deploy_id then %>
 				"deploy_id":"<%= $deploy_id %>"
 <% end %>
@@ -25,7 +25,7 @@
 		{
 			"name":"geoshape_geonode",
 			"vpc":{
-				"vpc_name":"<%=vpc_name %>",
+				"vpc_name":"<%=$vpc_name %>",
 <% if $deploy_id then %>
 				"deploy_id":"<%= $deploy_id %>"
 <% end %>
@@ -63,7 +63,7 @@
 		,{
 			"name":"postgres",
 			"vpc":{
-				"vpc_name":"<%=vpc_name %>",
+				"vpc_name":"<%=$vpc_name %>",
 <% if $deploy_id then %>
 				"deploy_id":"<%= $deploy_id %>"
 <% end %>

--- a/applications/geoshape_geonode/security_groups.json
+++ b/applications/geoshape_geonode/security_groups.json
@@ -2,14 +2,8 @@
 			"name":"geoshape_geonode_lb",
 			
 			"vpc":{
-<% if !$deploy_id then %>
-				"vpc_name": "geoshape-geonode-vpc"
-<% else %>
-	<% if $environment == "dev" then %>
-				"vpc_name":"dev-vpc",
-	<% elsif $environment == "prod" then %>
-				"vpc_name":"prod-vpc",
-	<% end %>
+				"vpc_name":"<%=vpc_name %>",
+<% if $deploy_id then %>
 				"deploy_id":"<%= $deploy_id %>"
 <% end %>
 			},
@@ -31,14 +25,8 @@
 		{
 			"name":"geoshape_geonode",
 			"vpc":{
-<% if !$deploy_id then %>
-				"vpc_name": "geoshape-geonode-vpc"
-<% else %>
-	<% if $environment == "dev" then %>
-				"vpc_name":"dev-vpc",
-	<% elsif $environment == "prod" then %>
-				"vpc_name":"prod-vpc",
-	<% end %>
+				"vpc_name":"<%=vpc_name %>",
+<% if $deploy_id then %>
 				"deploy_id":"<%= $deploy_id %>"
 <% end %>
 			},
@@ -75,14 +63,8 @@
 		,{
 			"name":"postgres",
 			"vpc":{
-<% if !$deploy_id then %>
-				"vpc_name": "geoshape-geonode-vpc"
-<% else %>
-	<% if $environment == "dev" then %>
-				"vpc_name":"dev-vpc",
-	<% elsif $environment == "prod" then %>
-				"vpc_name":"prod-vpc",
-	<% end %>
+				"vpc_name":"<%=vpc_name %>",
+<% if $deploy_id then %>
 				"deploy_id":"<%= $deploy_id %>"
 <% end %>
 			},

--- a/applications/geoshape_geonode/vpc.json
+++ b/applications/geoshape_geonode/vpc.json
@@ -1,5 +1,5 @@
 		{
-			"name": "geoshape-geonode-vpc",
+			"name": "<%=vpc_name %>",
 			"route-tables": [
 				{
 					"name": "internet",
@@ -15,7 +15,7 @@
 					"routes": [
 						{
 							"destination_network":"0.0.0.0/0",
-							"nat_host_name":"bastion"
+							"nat_host_name":"<%=$bastion_name %>",
 						}
 					]
 				}
@@ -23,7 +23,7 @@
 			"dependencies":[
 				{
 					"type":"server",
-					"name":"bastion"
+					"name":"<%=$bastion_name %>"
 				}
 			],
 			"subnets": [

--- a/applications/geoshape_geonode/vpc.json
+++ b/applications/geoshape_geonode/vpc.json
@@ -1,5 +1,5 @@
 		{
-			"name": "<%=vpc_name %>",
+			"name": "<%=$vpc_name %>",
 			"route-tables": [
 				{
 					"name": "internet",


### PR DESCRIPTION
* Intelligent defaulting up front in master BOKs
* Standard AMI defaulting
* Add more public subnets to allow for real loadbalancing with multiple private subnets
* Variable vpc_name for deploy to any VPC
* Some defaulting of subnets for lb etc per new abilities
* Using subnet_pref where it makes sense
* Preliminary OpenGeo from Ami, some issues remain